### PR TITLE
Clean up consul ui dir

### DIFF
--- a/consul/Dockerfile
+++ b/consul/Dockerfile
@@ -7,11 +7,10 @@ RUN  apk add --update ca-certificates openssl \
   && unzip consul_${CONSUL_VERSION}_linux_amd64.zip \
   && mv consul /bin/ \
   && rm -rf consul_${CONSUL_VERSION}_linux_amd64.zip \
-  && cd /tmp \
-  && wget -O ui.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_web_ui.zip \
-  && unzip ui.zip \
+  && wget -O /tmp/ui.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_web_ui.zip \
   && mkdir -p /ui \
-  && mv * /ui \
+  && cd /ui \
+  && unzip /tmp/ui.zip \
   && rm -rf /tmp/* /var/cache/apk/*
 
 EXPOSE 8300 8301 8301/udp 8302 8302/udp 8400 8500 8600 8600/udp

--- a/consul/Dockerfile
+++ b/consul/Dockerfile
@@ -2,7 +2,7 @@ FROM voxxit/base:alpine
 
 ENV CONSUL_VERSION 0.6.3
 
-RUN  apk add --update ca-certificates \
+RUN  apk add --update ca-certificates openssl \
   && wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip \
   && unzip consul_${CONSUL_VERSION}_linux_amd64.zip \
   && mv consul /bin/ \


### PR DESCRIPTION
Previously the ui.zip file was being left behind in /ui. Instead, download to /tmp and extract directly into /ui.
